### PR TITLE
Add documentation to rescale_catchments

### DIFF
--- a/R/rescale_catchments.R
+++ b/R/rescale_catchments.R
@@ -183,8 +183,6 @@ rescale_catchment_characteristics <- function(vars, lookup_table,
     # download characteristics for the requested comids
     catchment_characteristics <- get_catchment_characteristics(varname = vars$characteristic_id,
                                               ids = unique(lookup_table$comid))
-    # omit any duplicated rows in the returned attribute table
-    catchment_characteristics <- distinct(catchment_characteristics)
 
   }
 


### PR DESCRIPTION
This PR adds documentation for `rescale_catchment_characteristics()` and includes fixes related to dplyr warnings about function usage. 

Note that these changes also add a line to subset distinct rows of the `catchment_characteristics` data frame. I made this change in an attempt to deal with an edge case related to `CAT_IMPV11` that is described in more detail in #303, but we could omit if it's not needed.