### PR TITLE
retain and rescale percent_nodata column

### DIFF
--- a/R/get_vaa.R
+++ b/R/get_vaa.R
@@ -304,6 +304,8 @@ get_catchment_characteristics <- function(varname, ids, reference_fabric = "nhdp
         att$percent_nodata <- 0
       }
 
+      att <- mutate(att, percent_nodata = ifelse(is.na(.data[[i$ID]]), 100, percent_nodata))
+
       distinct(
       select(att, all_of(c(characteristic_id = "characteristic_id", comid = "COMID",
                            characteristic_value = x, percent_nodata = "percent_nodata"))))

--- a/R/rescale_catchments.R
+++ b/R/rescale_catchments.R
@@ -6,6 +6,11 @@ rescale_characteristics <- function(vars, lookup_table) {
   cols_min <- vars$characteristic_id[vars$summary_statistic == "min"]
   cols_max <- vars$characteristic_id[vars$summary_statistic == "max"]
 
+  vars_nodata <- names(select(lookup_table, starts_with("percent_nodata")))
+  if(length(vars_nodata) > 0) {
+    cols_area_wtd_mean <- c(cols_area_wtd_mean, vars_nodata)
+  }
+
   # rescale NHDPlusv2 attributes to desired catchments
   # !note that there are currently no adjustments made for the length of split flowlines
   lookup_table |>
@@ -190,9 +195,10 @@ rescale_catchment_characteristics <- function(vars, lookup_table,
 
   # pivot to wide format
   catchment_characteristics <- pivot_wider(catchment_characteristics,
-                                          id_cols = !"percent_nodata",
-                                          names_from = "characteristic_id",
-                                          values_from = "characteristic_value")
+                                           names_from = "characteristic_id",
+                                           values_from = c("characteristic_value", "percent_nodata"))
+  catchment_characteristics <- rename_with(.data = catchment_characteristics,
+                                           .fn = ~gsub("characteristic_value_", "", .x, fixed = TRUE))
 
   if(is.null(catchment_areas)) {
     # get comid catchment areas, adjusting area for catchments that have been "split"


### PR DESCRIPTION
This PR makes the following edits:

1. retain the `percent_nodata` column when pivoting the attributes to wide format in `rescale_catchment_characteristics()`, and 
2. rescale the `percent_nodata` values on an area-weighted basis when rescaling the attributes in `rescale_characteristics()`. For now, I've opted to return the area-weighted mean `percent_no data` values regardless of the requested summary statistic for a given attribute. 

I've also made a suggested change in `get_catchment_characteristics()` so that `percent_nodata` equals 100 for any rows where the attribute value was -9999 and is now `NA`. 

Here's an example to show what the output looks like (note that we end up with some pretty long column names, but for now I've kept the same format we use for the attributes themselves):

```r
vars <- data.frame(characteristic_id = c("CAT_EWT","CAT_BASIN_AREA"),
                   summary_statistic = c("area_weighted_mean","sum"))
lookup_table <- data.frame(id = 4203,
                           comid = c(8074226,8075830,932040118,932040186,932040187),
                           member_comid = c(8074226,8075830,932040118,932040186,932040187))
att <- rescale_catchment_characteristics(vars, lookup_table)
as.data.frame(att)
#>     id areasqkm_sum lengthkm_sum CAT_EWT_area_wtd percent_nodata_CAT_EWT_area_wtd percent_nodata_CAT_BASIN_AREA_area_wtd
#> 1 4203      22.7907       10.279                0                        50.57853                                      0
#>   CAT_BASIN_AREA_sum
#> 1               22.8
```

