### PR TITLE
Fix: Avoid timeout downloading issues

### DIFF
--- a/R/downloading_tools.R
+++ b/R/downloading_tools.R
@@ -74,6 +74,7 @@ download_nhdplushr <- function(nhd_dir, hu_list, download_files = TRUE) {
 
       if(download_files & !dir.exists(gsub(".zip", ".gdb", out_file)) &
          !dir.exists(file.path(dirname(out_file), paste0(hu04, ".gdb")))) {
+        options(timeout = 10000)
         download.file(url, out_file)
         zip::unzip(out_file, exdir = out[length(out)])
         unlink(out_file)


### PR DESCRIPTION
In downloading_tools.R, I added one line in the download_nhdplushr function to avoid having a 60 second download limit. now it is 10000 seconds (166 minutes).

I think this is useful for everybody when using this function